### PR TITLE
Export Wikimedia tables directly for easier import

### DIFF
--- a/.github/workflows/wiki.yaml
+++ b/.github/workflows/wiki.yaml
@@ -1,4 +1,5 @@
-on: 
+name: wiki
+on:
   push:
     paths: 
       - "BiggerReactors/src/main/resources/data/biggerreactors/**"
@@ -13,3 +14,13 @@ jobs:
         with:
           name: CSV
           path: BiggerReactors/build/data/*.csv
+  data_to_wikimedia:
+    name: Export data to Wikimedia table format
+    runs-on: Felix
+    steps:
+      - uses: actions/checkout@v2
+      - run: ./gradlew generateModeratorWikimedia generateCoilWikimedia
+      - uses: actions/upload-artifact@v2
+        with:
+          name: WikiMedia
+          path: BiggerReactors/build/data/*.txt

--- a/BiggerReactors/build.gradle
+++ b/BiggerReactors/build.gradle
@@ -222,3 +222,13 @@ task generateCoilCsv(type: net.roguelogix.Json5ToCsvTask) {
     jsonInputs = fileTree(dir: "src/main/resources/data/biggerreactors/ebest/coils/", include: "**/*.json*")
     csvOutput = file("$buildDir/data/coils.csv")
 }
+
+task generateModeratorWikimedia(type: net.roguelogix.CsvToWikimediaTask, dependsOn: generateModeratorCsv) {
+    csvInput = generateModeratorCsv.outputs.files[0]
+    txtOutput = file("$buildDir/data/moderators.txt")
+}
+
+task generateCoilWikimedia(type: net.roguelogix.CsvToWikimediaTask, dependsOn: generateCoilCsv) {
+    csvInput = generateCoilCsv.outputs.files[0]
+    txtOutput = file("$buildDir/data/coils.txt")
+}

--- a/buildSrc/src/main/groovy/net/roguelogix/CsvToWikimediaTask.groovy
+++ b/buildSrc/src/main/groovy/net/roguelogix/CsvToWikimediaTask.groovy
@@ -1,0 +1,33 @@
+package net.roguelogix
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+class CsvToWikimediaTask extends DefaultTask {
+    @InputFile
+    File csvInput
+
+    @OutputFile
+    File txtOutput
+
+    @TaskAction
+    void process() {
+        def rows = csvInput.readLines().collect {it.replace(",", " || ")}
+        rows.subList(1, rows.size()).sort()
+
+        txtOutput.withWriter {
+            it.writeLine('{| class="wikitable sortable"')
+            rows.eachWithIndex { row, index ->
+                if (index == 0) {
+                    it.writeLine('! ' + row)
+                } else {
+                    it.writeLine('| ' + row)
+                }
+                it.writeLine('|-')
+            }
+            it.writeLine("|}")
+        }
+    }
+}


### PR DESCRIPTION
Wikimedia doesn't have CSV import support, so this exports directly to Wikimedia table format for easy copy/paste updates. This could replace the CSV export instead if you prefer, since that was the intent of the CSV format to begin with.