### PR TITLE
make JEI plugin work in SMP

### DIFF
--- a/BiggerReactors/src/main/java/net/roguelogix/biggerreactors/BiggerReactors.java
+++ b/BiggerReactors/src/main/java/net/roguelogix/biggerreactors/BiggerReactors.java
@@ -3,6 +3,7 @@ package net.roguelogix.biggerreactors;
 import net.minecraft.client.gui.ScreenManager;
 import net.minecraft.resources.IResourceManager;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.AddReloadListenerEvent;
@@ -46,6 +47,7 @@ public class BiggerReactors {
         MinecraftForge.EVENT_BUS.addListener(this::onAddReloadListenerEvent);
         MinecraftForge.EVENT_BUS.addListener(this::onServerStopped);
         if (FMLEnvironment.dist == Dist.CLIENT) {
+            MinecraftForge.EVENT_BUS.addListener(this::onClientJoinWorld);
             MinecraftForge.EVENT_BUS.addListener(this::onRenderWorldLast);
         }
 
@@ -90,7 +92,9 @@ public class BiggerReactors {
                 TurbineCoolantPortScreen::new);
 
         ClientRegistry.bindTileEntityRenderer(TurbineRotorBearingTile.TYPE, BladeRenderer::new);
+    }
 
+    public void onClientJoinWorld(ClientPlayerNetworkEvent.LoggedInEvent event) {
         resourceManager = ClientUtils.getResourceManager();
     }
 

--- a/BiggerReactors/src/main/java/net/roguelogix/biggerreactors/BiggerReactors.java
+++ b/BiggerReactors/src/main/java/net/roguelogix/biggerreactors/BiggerReactors.java
@@ -1,7 +1,7 @@
 package net.roguelogix.biggerreactors;
 
 import net.minecraft.client.gui.ScreenManager;
-import net.minecraft.resources.DataPackRegistries;
+import net.minecraft.resources.IResourceManager;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.common.MinecraftForge;
@@ -26,6 +26,7 @@ import net.roguelogix.biggerreactors.classic.turbine.client.TurbineTerminalScree
 import net.roguelogix.biggerreactors.classic.turbine.containers.TurbineCoolantPortContainer;
 import net.roguelogix.biggerreactors.classic.turbine.containers.TurbineTerminalContainer;
 import net.roguelogix.biggerreactors.classic.turbine.tiles.TurbineRotorBearingTile;
+import net.roguelogix.biggerreactors.client.ClientUtils;
 import net.roguelogix.phosphophyllite.registry.Registry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,18 +51,18 @@ public class BiggerReactors {
 
     }
 
-    public static DataPackRegistries dataPackRegistries;
+    public static IResourceManager resourceManager;
 
     public void onAddReloadListenerEvent(AddReloadListenerEvent reloadListenerEvent) {
-        dataPackRegistries = reloadListenerEvent.getDataPackRegistries();
+        resourceManager = reloadListenerEvent.getDataPackRegistries().getResourceManager();
     }
     
     public void onServerStopped(FMLServerStoppedEvent serverStoppedEvent){
-        dataPackRegistries = null;
+        resourceManager = null;
     }
 
     public void onTagsUpdatedEvent(final TagsUpdatedEvent.CustomTagTypes tagsUpdatedEvent) {
-        if(dataPackRegistries == null){
+        if(resourceManager == null){
             return;
         }
         ReactorModeratorRegistry.loadRegistry(tagsUpdatedEvent.getTagManager().getBlockTags());
@@ -89,6 +90,8 @@ public class BiggerReactors {
                 TurbineCoolantPortScreen::new);
 
         ClientRegistry.bindTileEntityRenderer(TurbineRotorBearingTile.TYPE, BladeRenderer::new);
+
+        resourceManager = ClientUtils.getResourceManager();
     }
 
     public static long lastRenderTime = 0;

--- a/BiggerReactors/src/main/java/net/roguelogix/biggerreactors/classic/reactor/ReactorModeratorRegistry.java
+++ b/BiggerReactors/src/main/java/net/roguelogix/biggerreactors/classic/reactor/ReactorModeratorRegistry.java
@@ -56,7 +56,7 @@ public class ReactorModeratorRegistry {
         BiggerReactors.LOGGER.info("Loading reactor moderators");
         registry.clear();
         // TODO: generify this code in Phosphophyllite
-        IResourceManager resourceManager = BiggerReactors.dataPackRegistries.getResourceManager();
+        IResourceManager resourceManager = BiggerReactors.resourceManager;
         Collection<ResourceLocation> resourceLocations = resourceManager.getAllResourceLocations("ebcr/moderators", s -> s.contains(".json"));
         
         for (ResourceLocation resourceLocation : resourceLocations) {

--- a/BiggerReactors/src/main/java/net/roguelogix/biggerreactors/classic/turbine/TurbineCoilRegistry.java
+++ b/BiggerReactors/src/main/java/net/roguelogix/biggerreactors/classic/turbine/TurbineCoilRegistry.java
@@ -53,7 +53,7 @@ public class TurbineCoilRegistry {
         BiggerReactors.LOGGER.info("Loading turbine coils");
         registry.clear();
         // TODO: generify this code in Phosphophyllite
-        IResourceManager resourceManager = BiggerReactors.dataPackRegistries.getResourceManager();
+        IResourceManager resourceManager = BiggerReactors.resourceManager;
         Collection<ResourceLocation> resourceLocations = resourceManager.getAllResourceLocations("ebest/coils", s -> s.contains(".json"));
         
         for (ResourceLocation resourceLocation : resourceLocations) {

--- a/BiggerReactors/src/main/java/net/roguelogix/biggerreactors/client/ClientUtils.java
+++ b/BiggerReactors/src/main/java/net/roguelogix/biggerreactors/client/ClientUtils.java
@@ -1,0 +1,10 @@
+package net.roguelogix.biggerreactors.client;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.IResourceManager;
+
+public class ClientUtils {
+    public static IResourceManager getResourceManager() {
+        return Minecraft.getInstance().getResourceManager();
+    }
+}


### PR DESCRIPTION
Only loads client-side resources, does not account for datapacks that are only on the server or only on the client.

That can be done with custom packets on login and reload, but this covers most use cases.